### PR TITLE
arruma link quebrado

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - 🌱 I’m currently learning **Julia**
 
-- 📝 I regulary write articles on [azul.netlify.app](azul.netlify.app)
+- 📝 I regulary write articles on [azul.netlify.app](http://https://azul.netlify.app)
 
 - 📫 How to reach me **pedrocolrj@gmail.com**
 


### PR DESCRIPTION
Oi Pedro! Cheguei através do linktree, cliquei pra o blog e percebi que o link encaminha para o erro 404 pq faltou o `https://`. :)